### PR TITLE
Fix return body for DescribeTimeToLive

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,15 +18,21 @@ app.use((ctx, next) => {
     };
   }
   else if (ctx.header['x-amz-target'] === 'DynamoDB_20120810.DescribeTimeToLive') {
-    if (!tableTtlMap[ctx.request.body['TableName']])
-      ctx.boxy = {};
-    else
+    if (!tableTtlMap[ctx.request.body['TableName']]) {
+      ctx.body = {
+        'TimeToLiveDescription': {
+          'TimeToLiveStatus': 'DISABLED'
+        }
+      };
+    } else {
       ctx.body = {
         'TimeToLiveDescription': {
           'AttributeName': tableTtlMap[ctx.request.body['TableName']]['AttributeName'],
           "TimeToLiveStatus": tableTtlMap[ctx.request.body['TableName']]['Status'] ? 'ENABLED' : 'DISABLED'
         }
       };
+    }
+
   }
   else if (ctx.header['x-amz-target'] === 'DynamoDB_20120810.TagResource' || ctx.header['x-amz-target'] === 'DynamoDB_20120810.UntagResource') {
     ctx.status = 200;


### PR DESCRIPTION
#1 The problem was still persistent as it was written: **ctx.boxy** instead of **ctx.body** . Actually, DynamoDB will return status: DISABLE instead of an empty array.
This Pull request does not handle the case of unknown tables