### PR TITLE
Separating the unsupported API mock from Dynamodb  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,9 @@
-FROM openjdk:8-jre-slim
+FROM node:8.16.2-alpine
 
-LABEL maintainer="stevenao"
+WORKDIR /usr/src/app
 
-ENV DYNAMODB_LOCAL_DIR /opt/dynamodb_local
-ENV APP_DIR /opt/app_server
+COPY . .
 
-WORKDIR $DYNAMODB_LOCAL_DIR
+RUN npm install --prod
 
-VOLUME ["/dynamodb_local_db"]
-
-ENV DYNAMODB_VERSION=latest
-
-ENV JAVA_OPTS=
-
-RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y --no-install-recommends nodejs && \
-    curl -O https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_${DYNAMODB_VERSION}.tar.gz && \
-    tar zxvf dynamodb_local_${DYNAMODB_VERSION}.tar.gz && \
-    rm dynamodb_local_${DYNAMODB_VERSION}.tar.gz && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
-    
-COPY . $APP_DIR
-
-RUN cd $APP_DIR && npm install --prod && cd $DYNAMODB_LOCAL_DIR
-
-ENTRYPOINT exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar --sharedDb -dbPath /dynamodb_local_db -port 45670 & cd $APP_DIR && npm run start
-
-EXPOSE 4567
+ENTRYPOINT ["sh", "-c", "npm run start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.4"
+services:
+  dynamodb_local_mock_unsupported_api:
+    depends_on:
+      - dynamodb
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - DYNAMO_HOST=dynamodb
+      - DYNAMO_PORT=8000
+    ports:
+      - 8002:4567
+      -
+  dynamodb:
+    image: amazon/dynamodb-local:1.11.477
+    command: -jar DynamoDBLocal.jar -inMemory -sharedDb
+    ports:
+      - 3307:8000
+    environment:
+      - AWS_ACCESS_KEY_ID=access_key
+      - AWS_SECRET_ACCESS_KEY=secret_key
+      - "AWS_DEFAULT_REGION=eu-west-1"

--- a/index.js
+++ b/index.js
@@ -55,4 +55,4 @@ app.use(proxy({
   host: 'http://' + DYNAMO_HOST + ':' + DYNAMO_PORT
 })).listen(4567);
 
-console.log('started server at http://localhost:4567');
+console.log('started server at http://0.0.0.0:4567');

--- a/makefile
+++ b/makefile
@@ -1,0 +1,6 @@
+version=latest
+repository=mwaaas/dynamodb_local_mock_unsupported_api:$(version)
+
+deploy:
+	docker build -t $(repository) .
+	docker push $(repository)


### PR DESCRIPTION
# What 
Separating the unsupported API mock from Dynamodb 

# Why 
- For easy upgrading Dynamodb image without having to rebuild Dynamodb unsupported mock  
- For easy revert, if those APIs are created in Dynamodb 
